### PR TITLE
Add CLI for converting images to STL heightmaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,27 @@
-- 👋 Hi, I’m @omgawdmadeit1
-- 👀 I’m interested in ...
-- 🌱 I’m currently learning ...
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
+# Image → 3D-print STL converter
 
-<!---
-omgawdmadeit1/omgawdmadeit1 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+Convert any image into a 3D-printable STL heightmap with a CLI built on Pillow, NumPy, and trimesh.
+
+## Setup
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python image_to_3d_converter.py input.png output.stl \
+  --max-height 5.0 \    # millimeters on top of the base
+  --base-height 1.0 \   # base plate thickness in millimeters
+  --pixel-size 0.2 \    # XY size of one pixel in millimeters
+  --invert              # optional: make darker pixels taller
+```
+
+Tips:
+
+- Use high-contrast grayscale images for crisp heightmaps.
+- The base height ensures the thinnest areas remain printable.
+- The output STL is watertight and ready for your slicer.

--- a/image_to_3d_converter.py
+++ b/image_to_3d_converter.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+import numpy as np
+from PIL import Image
+import trimesh
+
+
+@dataclass
+class ConversionConfig:
+    image_path: Path
+    output_path: Path
+    max_height: float = 5.0
+    base_height: float = 1.0
+    pixel_size: float = 0.2
+    invert: bool = False
+
+
+def load_grayscale(image_path: Path) -> np.ndarray:
+    """Load an image and return a 2D numpy array normalized to [0, 1]."""
+    image = Image.open(image_path).convert("L")
+    data = np.asarray(image, dtype=np.float32) / 255.0
+    return data
+
+
+def build_heightmap(image_data: np.ndarray, max_height: float, base_height: float, invert: bool) -> np.ndarray:
+    normalized = 1.0 - image_data if invert else image_data
+    return base_height + normalized * max_height
+
+
+def _quad(a: int, b: int, c: int, d: int) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
+    """Return two faces that compose a quad (a-b-c-d order)."""
+    return (a, b, d), (a, d, c)
+
+
+def heightmap_to_mesh(heightmap: np.ndarray, pixel_size: float) -> trimesh.Trimesh:
+    rows, cols = heightmap.shape
+    xs, ys = np.meshgrid(np.arange(cols, dtype=np.float32), np.arange(rows, dtype=np.float32))
+
+    top_vertices = np.column_stack((xs.ravel() * pixel_size, ys.ravel() * pixel_size, heightmap.ravel()))
+    bottom_vertices = np.column_stack((xs.ravel() * pixel_size, ys.ravel() * pixel_size, np.zeros_like(heightmap).ravel()))
+
+    vertices = np.vstack((top_vertices, bottom_vertices))
+
+    def t_idx(r: int, c: int) -> int:
+        return r * cols + c
+
+    def b_idx(r: int, c: int) -> int:
+        return rows * cols + r * cols + c
+
+    faces: list[Iterable[int]] = []
+
+    # Top surface
+    for r in range(rows - 1):
+        for c in range(cols - 1):
+            a, b, c2, d = t_idx(r, c), t_idx(r, c + 1), t_idx(r + 1, c), t_idx(r + 1, c + 1)
+            faces.extend(_quad(a, b, c2, d))
+
+    # Bottom surface (reverse winding for outward normals)
+    for r in range(rows - 1):
+        for c in range(cols - 1):
+            a, b, c2, d = b_idx(r, c), b_idx(r, c + 1), b_idx(r + 1, c), b_idx(r + 1, c + 1)
+            bottom_faces = [(a, b, d), (a, d, c2)]
+            faces.extend([(face[2], face[1], face[0]) for face in bottom_faces])
+
+    # Side walls
+    for c in range(cols - 1):
+        # North edge (r = 0)
+        faces.extend(
+            _quad(
+                b_idx(0, c),
+                b_idx(0, c + 1),
+                t_idx(0, c),
+                t_idx(0, c + 1),
+            )
+        )
+        # South edge (r = rows - 1)
+        faces.extend(
+            _quad(
+                b_idx(rows - 1, c),
+                b_idx(rows - 1, c + 1),
+                t_idx(rows - 1, c),
+                t_idx(rows - 1, c + 1),
+            )
+        )
+
+    for r in range(rows - 1):
+        # West edge (c = 0)
+        faces.extend(
+            _quad(
+                b_idx(r, 0),
+                b_idx(r + 1, 0),
+                t_idx(r, 0),
+                t_idx(r + 1, 0),
+            )
+        )
+        # East edge (c = cols - 1)
+        faces.extend(
+            _quad(
+                b_idx(r, cols - 1),
+                b_idx(r + 1, cols - 1),
+                t_idx(r, cols - 1),
+                t_idx(r + 1, cols - 1),
+            )
+        )
+
+    mesh = trimesh.Trimesh(vertices=vertices, faces=np.array(faces, dtype=np.int64), process=True)
+    mesh.merge_vertices()
+    return mesh
+
+
+def convert(config: ConversionConfig) -> trimesh.Trimesh:
+    image_data = load_grayscale(config.image_path)
+    heightmap = build_heightmap(image_data, config.max_height, config.base_height, config.invert)
+    mesh = heightmap_to_mesh(heightmap, config.pixel_size)
+    mesh.export(config.output_path)
+    return mesh
+
+
+def parse_args() -> ConversionConfig:
+    parser = argparse.ArgumentParser(description="Convert an image to an STL heightmap for 3D printing.")
+    parser.add_argument("image", type=Path, help="Path to the input image file")
+    parser.add_argument("output", type=Path, help="Destination STL path")
+    parser.add_argument("--max-height", type=float, default=5.0, help="Maximum height added on top of the base in mm")
+    parser.add_argument("--base-height", type=float, default=1.0, help="Base thickness in mm")
+    parser.add_argument("--pixel-size", type=float, default=0.2, help="Size of one pixel in mm")
+    parser.add_argument("--invert", action="store_true", help="Invert brightness so dark areas are tallest")
+    args = parser.parse_args()
+    return ConversionConfig(
+        image_path=args.image,
+        output_path=args.output,
+        max_height=args.max_height,
+        base_height=args.base_height,
+        pixel_size=args.pixel_size,
+        invert=args.invert,
+    )
+
+
+def main() -> None:
+    config = parse_args()
+    convert(config)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+numpy
+Pillow
+trimesh

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,0 +1,31 @@
+import numpy as np
+from PIL import Image
+
+from image_to_3d_converter import ConversionConfig, convert
+
+
+def test_conversion_creates_watertight_mesh(tmp_path):
+    pixel_values = np.array([[0, 128], [255, 255]], dtype=np.uint8)
+    image = Image.fromarray(pixel_values, mode="L")
+    image_path = tmp_path / "test.png"
+    stl_path = tmp_path / "out.stl"
+    image.save(image_path)
+
+    config = ConversionConfig(
+        image_path=image_path,
+        output_path=stl_path,
+        max_height=2.0,
+        base_height=1.0,
+        pixel_size=1.0,
+        invert=False,
+    )
+
+    mesh = convert(config)
+
+    assert stl_path.exists()
+    assert mesh.is_watertight
+
+    mins, maxs = mesh.bounds
+    assert np.isclose(mins[2], 0.0)
+    assert np.isclose(maxs[2], 3.0)  # base (1mm) + max height (2mm)
+    assert mesh.faces.shape[0] > 0


### PR DESCRIPTION
## Summary
- add a Python CLI that turns grayscale images into watertight STL heightmaps with base thickness and pixel sizing options
- document setup and usage alongside runtime dependencies
- add a pytest to ensure the generated mesh is watertight and bounded as expected

## Testing
- python -m pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ffb1e04d88324adbd9ff940fe73ea)