### PR TITLE
Add Next.js X auto-poster app with OAuth PKCE, scheduler, Prisma schema, and safety controls

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+X_CLIENT_ID=
+X_CLIENT_SECRET=
+X_REDIRECT_URI=http://localhost:3000/api/auth/x/callback
+DATABASE_URL=file:./dev.db
+CRON_SECRET=
+NEXT_PUBLIC_APP_URL=http://localhost:3000

--- a/README.md
+++ b/README.md
@@ -1,10 +1,87 @@
-- 👋 Hi, I’m @omgawdmadeit1
-- 👀 I’m interested in ...
-- 🌱 I’m currently learning ...
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
+# Safe X Auto Poster (Next.js + TypeScript)
 
-<!---
-omgawdmadeit1/omgawdmadeit1 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+A safe-by-default X auto-poster app for drafting, scheduling, and publishing posts through the **official X API v2** with OAuth 2.0 + PKCE.
+
+## Features
+- Connect X account via OAuth 2.0 + PKCE.
+- Create drafts and scheduled posts.
+- Manual **Post Now** action.
+- Minute-based cron scheduler endpoint.
+- Retry logic for failed posts.
+- Rate-limit handling (`429` + reset time).
+- Publish attempt logs.
+- Safety controls:
+  - safety delay between posts,
+  - daily posting limit,
+  - approval requirement toggle.
+- SQLite via Prisma.
+
+## Tech Stack
+- Next.js App Router
+- TypeScript
+- Tailwind CSS
+- Prisma + SQLite
+- X API v2
+
+## Environment Variables
+Copy `.env.example` to `.env` and set values:
+- `X_CLIENT_ID`
+- `X_CLIENT_SECRET`
+- `X_REDIRECT_URI`
+- `DATABASE_URL`
+- `CRON_SECRET`
+- `NEXT_PUBLIC_APP_URL` (optional)
+
+## Local Setup
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Configure environment:
+   ```bash
+   cp .env.example .env
+   ```
+3. Push schema:
+   ```bash
+   npx prisma db push
+   ```
+4. Seed default user:
+   ```bash
+   npm run db:seed
+   ```
+5. Start app:
+   ```bash
+   npm run dev
+   ```
+
+## Scheduler
+Call cron endpoint every minute:
+- `POST /api/cron/publish`
+- header `x-cron-secret: <CRON_SECRET>`
+
+### Example cron call
+```bash
+curl -X POST http://localhost:3000/api/cron/publish -H "x-cron-secret: your-secret"
+```
+
+## API Routes
+- `GET /api/auth/x/login` → start OAuth flow.
+- `GET /api/auth/x/callback` → OAuth callback + token save.
+- `GET /api/posts` → list posts + logs.
+- `POST /api/posts` → create draft/scheduled post.
+- `POST /api/posts/:id/publish` → manual publish now.
+- `POST /api/cron/publish` → publish due scheduled posts.
+
+## Deployment (Vercel)
+1. Push repo to Git provider.
+2. Import project into Vercel.
+3. Add environment variables in Vercel Project Settings.
+4. Add a Vercel Cron Job to call `/api/cron/publish` every minute.
+5. Run `prisma db push` against your production DB (SQLite persistent disk or move to Supabase/Postgres by editing Prisma datasource).
+
+## Compliance Notes
+- Uses only official X API endpoints.
+- No spam reply automation, scraping, mass DMs, or unsolicited engagement features.
+- Includes duplicate-prevention expectation (implement stricter text hashing if needed for production).
+- Enforces safety delay and daily limits in publishing logic.
+- Supports approval gate before publishing.

--- a/app/api/auth/x/callback/route.ts
+++ b/app/api/auth/x/callback/route.ts
@@ -1,0 +1,25 @@
+import { exchangeCodeForToken } from "@/lib/x-client";
+import { prisma } from "@/lib/prisma";
+import { cookies } from "next/headers";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function GET(req: NextRequest) {
+  const params = req.nextUrl.searchParams;
+  const code = params.get("code");
+  const state = params.get("state");
+  const cookieStore = await cookies();
+  const savedState = cookieStore.get("x_state")?.value;
+  const verifier = cookieStore.get("x_code_verifier")?.value;
+  if (!code || !state || !savedState || state !== savedState || !verifier) {
+    return NextResponse.json({ error: "Invalid auth callback" }, { status: 400 });
+  }
+
+  const token = await exchangeCodeForToken(code, verifier);
+  await prisma.user.upsert({
+    where: { id: "default-user" },
+    update: { accessToken: token.access_token, refreshToken: token.refresh_token },
+    create: { id: "default-user", accessToken: token.access_token, refreshToken: token.refresh_token },
+  });
+
+  return NextResponse.redirect(new URL("/", req.url));
+}

--- a/app/api/auth/x/login/route.ts
+++ b/app/api/auth/x/login/route.ts
@@ -1,0 +1,13 @@
+import { env } from "@/lib/env";
+import { createAuthUrl, createPkcePair } from "@/lib/x-auth";
+import { cookies } from "next/headers";
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const { verifier, challenge, state } = createPkcePair();
+  const cookieStore = await cookies();
+  cookieStore.set("x_code_verifier", verifier, { httpOnly: true, secure: true, sameSite: "lax", path: "/" });
+  cookieStore.set("x_state", state, { httpOnly: true, secure: true, sameSite: "lax", path: "/" });
+  const url = createAuthUrl(env.X_CLIENT_ID, env.X_REDIRECT_URI, challenge, state);
+  return NextResponse.redirect(url);
+}

--- a/app/api/cron/publish/route.ts
+++ b/app/api/cron/publish/route.ts
@@ -1,0 +1,28 @@
+import { env } from "@/lib/env";
+import { publishPost } from "@/lib/publisher";
+import { prisma } from "@/lib/prisma";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(req: NextRequest) {
+  if (req.headers.get("x-cron-secret") !== env.CRON_SECRET) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const due = await prisma.post.findMany({
+    where: { status: "SCHEDULED", scheduledFor: { lte: new Date() } },
+    orderBy: { scheduledFor: "asc" },
+    take: 20,
+  });
+
+  const results = [] as Array<{ postId: string; ok: boolean; error?: string }>;
+  for (const post of due) {
+    try {
+      await publishPost(post.id);
+      results.push({ postId: post.id, ok: true });
+    } catch (error) {
+      results.push({ postId: post.id, ok: false, error: error instanceof Error ? error.message : "Unknown error" });
+    }
+  }
+
+  return NextResponse.json({ processed: due.length, results });
+}

--- a/app/api/posts/[id]/publish/route.ts
+++ b/app/api/posts/[id]/publish/route.ts
@@ -1,0 +1,11 @@
+import { publishPost } from "@/lib/publisher";
+import { NextRequest, NextResponse } from "next/server";
+
+export async function POST(_: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    await publishPost(params.id);
+    return NextResponse.json({ ok: true });
+  } catch (error) {
+    return NextResponse.json({ ok: false, error: error instanceof Error ? error.message : "Unknown error" }, { status: 400 });
+  }
+}

--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -1,0 +1,34 @@
+import { prisma } from "@/lib/prisma";
+import { PostStatus } from "@prisma/client";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+const bodySchema = z.object({
+  content: z.string().min(1).max(280),
+  scheduledFor: z.string().datetime().optional(),
+  approved: z.boolean().optional(),
+});
+
+export async function GET() {
+  const posts = await prisma.post.findMany({ orderBy: { createdAt: "desc" }, take: 100, include: { logs: true } });
+  return NextResponse.json(posts);
+}
+
+export async function POST(req: NextRequest) {
+  const data = bodySchema.parse(await req.json());
+  const existingDuplicate = await prisma.post.findFirst({
+    where: { userId: "default-user", content: data.content, status: { in: ["DRAFT", "SCHEDULED"] } },
+  });
+  if (existingDuplicate) return NextResponse.json({ error: "Duplicate draft/scheduled content blocked" }, { status: 409 });
+
+  const post = await prisma.post.create({
+    data: {
+      userId: "default-user",
+      content: data.content,
+      status: data.scheduledFor ? PostStatus.SCHEDULED : PostStatus.DRAFT,
+      scheduledFor: data.scheduledFor ? new Date(data.scheduledFor) : null,
+      approved: data.approved ?? false,
+    },
+  });
+  return NextResponse.json(post, { status: 201 });
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,5 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body { @apply bg-slate-950 text-slate-100; }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import "./globals.css";
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "X Auto Poster",
+  description: "Safe scheduler and publisher for X posts",
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen">{children}</body>
+    </html>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import { Dashboard } from "@/components/dashboard";
+
+export default function Home() {
+  return <Dashboard />;
+}

--- a/components/dashboard.tsx
+++ b/components/dashboard.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+type Post = {
+  id: string;
+  content: string;
+  status: string;
+  scheduledFor: string | null;
+  approved: boolean;
+  logs: Array<{ id: string; success: boolean; message: string; attemptedAt: string }>;
+};
+
+export function Dashboard() {
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [content, setContent] = useState("");
+  const [scheduledFor, setScheduledFor] = useState("");
+  const [approved, setApproved] = useState(false);
+
+  async function refresh() {
+    const res = await fetch("/api/posts");
+    setPosts(await res.json());
+  }
+
+  useEffect(() => { void refresh(); }, []);
+
+  async function submit() {
+    await fetch("/api/posts", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content, scheduledFor: scheduledFor || undefined, approved }),
+    });
+    setContent("");
+    setScheduledFor("");
+    setApproved(false);
+    await refresh();
+  }
+
+  async function postNow(id: string) {
+    await fetch(`/api/posts/${id}/publish`, { method: "POST" });
+    await refresh();
+  }
+
+  return (
+    <main className="mx-auto max-w-4xl p-8 space-y-8">
+      <h1 className="text-2xl font-bold">X Auto Poster Dashboard</h1>
+      <a className="underline" href="/api/auth/x/login">Connect X Account</a>
+      <div className="space-y-2 rounded border border-slate-700 p-4">
+        <textarea className="w-full rounded bg-slate-900 p-2" value={content} onChange={(e) => setContent(e.target.value)} placeholder="Write post" />
+        <input className="rounded bg-slate-900 p-2" type="datetime-local" value={scheduledFor} onChange={(e) => setScheduledFor(e.target.value)} />
+        <label className="flex items-center gap-2"><input type="checkbox" checked={approved} onChange={(e) => setApproved(e.target.checked)} />Approved</label>
+        <button className="rounded bg-blue-600 px-4 py-2" onClick={submit}>Save Post</button>
+      </div>
+      <div className="space-y-4">
+        {posts.map((p) => (
+          <div key={p.id} className="rounded border border-slate-700 p-4">
+            <div className="flex items-center justify-between">
+              <p>{p.content}</p>
+              <button className="rounded bg-emerald-700 px-3 py-1" onClick={() => postNow(p.id)}>Post Now</button>
+            </div>
+            <p className="text-sm">Status: {p.status} {p.scheduledFor ? `(scheduled ${new Date(p.scheduledFor).toLocaleString()})` : ""}</p>
+            <p className="text-sm">Approved: {String(p.approved)}</p>
+            <ul className="mt-2 text-xs text-slate-300">{p.logs.map((l) => <li key={l.id}>{l.attemptedAt}: {l.success ? "✅" : "❌"} {l.message}</li>)}</ul>
+          </div>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,12 @@
+import { z } from "zod";
+
+const envSchema = z.object({
+  DATABASE_URL: z.string().min(1),
+  X_CLIENT_ID: z.string().min(1),
+  X_CLIENT_SECRET: z.string().min(1),
+  X_REDIRECT_URI: z.string().url(),
+  CRON_SECRET: z.string().min(1),
+  NEXT_PUBLIC_APP_URL: z.string().url().optional(),
+});
+
+export const env = envSchema.parse(process.env);

--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,0 +1,11 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as { prisma: PrismaClient | undefined };
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: ["warn", "error"],
+  });
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;

--- a/lib/publisher.ts
+++ b/lib/publisher.ts
@@ -1,0 +1,61 @@
+import { prisma } from "@/lib/prisma";
+import { createTweet } from "@/lib/x-client";
+
+const SAFETY_DELAY_MS = 60_000;
+const MAX_RETRIES = 3;
+
+export async function publishPost(postId: string) {
+  const post = await prisma.post.findUnique({ where: { id: postId }, include: { user: true } });
+  if (!post) throw new Error("Post not found");
+  if (!post.user.accessToken) throw new Error("User is not connected to X");
+  if (post.user.requireApproval && !post.approved) throw new Error("Post requires approval");
+
+  const todayStart = new Date();
+  todayStart.setUTCHours(0, 0, 0, 0);
+  const todayEnd = new Date();
+  todayEnd.setUTCHours(23, 59, 59, 999);
+
+  const publishedToday = await prisma.post.count({
+    where: { userId: post.userId, status: "PUBLISHED", publishedAt: { gte: todayStart, lte: todayEnd } },
+  });
+  if (publishedToday >= post.user.dailyPostLimit) throw new Error("Daily post limit reached");
+
+  const latestPublish = await prisma.post.findFirst({
+    where: { userId: post.userId, status: "PUBLISHED" },
+    orderBy: { publishedAt: "desc" },
+  });
+  if (latestPublish?.publishedAt && Date.now() - latestPublish.publishedAt.getTime() < SAFETY_DELAY_MS) {
+    throw new Error("Safety delay active");
+  }
+
+  if (post.user.rateLimitedUntil && post.user.rateLimitedUntil > new Date()) {
+    throw new Error(`Rate limited until ${post.user.rateLimitedUntil.toISOString()}`);
+  }
+
+  try {
+    const response = await createTweet(post.user.accessToken, post.content);
+    if (!response.ok) {
+      await prisma.user.update({ where: { id: post.userId }, data: { rateLimitedUntil: response.rateLimitedUntil } });
+      await prisma.publishLog.create({ data: { postId, success: false, statusCode: 429, message: "Rate limited" } });
+      return;
+    }
+
+    await prisma.post.update({ where: { id: postId }, data: { status: "PUBLISHED", publishedAt: new Date(), lastAttemptAt: new Date() } });
+    await prisma.publishLog.create({ data: { postId, success: true, statusCode: 201, message: "Published" } });
+  } catch (error) {
+    const retryCount = post.retryCount + 1;
+    await prisma.post.update({
+      where: { id: postId },
+      data: {
+        retryCount,
+        lastAttemptAt: new Date(),
+        status: retryCount >= MAX_RETRIES ? "FAILED" : "SCHEDULED",
+        scheduledFor: retryCount >= MAX_RETRIES ? post.scheduledFor : new Date(Date.now() + retryCount * 60_000),
+      },
+    });
+    await prisma.publishLog.create({
+      data: { postId, success: false, message: error instanceof Error ? error.message : "Unknown publish error" },
+    });
+    throw error;
+  }
+}

--- a/lib/x-auth.ts
+++ b/lib/x-auth.ts
@@ -1,0 +1,22 @@
+import crypto from "node:crypto";
+
+const SCOPE = "tweet.read tweet.write users.read offline.access";
+
+export function createPkcePair() {
+  const verifier = crypto.randomBytes(32).toString("base64url");
+  const challenge = crypto.createHash("sha256").update(verifier).digest("base64url");
+  const state = crypto.randomBytes(16).toString("hex");
+  return { verifier, challenge, state };
+}
+
+export function createAuthUrl(clientId: string, redirectUri: string, challenge: string, state: string) {
+  const url = new URL("https://twitter.com/i/oauth2/authorize");
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", clientId);
+  url.searchParams.set("redirect_uri", redirectUri);
+  url.searchParams.set("scope", SCOPE);
+  url.searchParams.set("state", state);
+  url.searchParams.set("code_challenge", challenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  return url.toString();
+}

--- a/lib/x-client.ts
+++ b/lib/x-client.ts
@@ -1,0 +1,44 @@
+import { env } from "@/lib/env";
+
+export type XTokenResponse = {
+  token_type: string;
+  expires_in: number;
+  access_token: string;
+  scope: string;
+  refresh_token?: string;
+};
+
+export async function exchangeCodeForToken(code: string, codeVerifier: string) {
+  const auth = Buffer.from(`${env.X_CLIENT_ID}:${env.X_CLIENT_SECRET}`).toString("base64");
+  const body = new URLSearchParams({
+    grant_type: "authorization_code",
+    code,
+    redirect_uri: env.X_REDIRECT_URI,
+    code_verifier: codeVerifier,
+  });
+
+  const res = await fetch("https://api.x.com/2/oauth2/token", {
+    method: "POST",
+    headers: { Authorization: `Basic ${auth}`, "Content-Type": "application/x-www-form-urlencoded" },
+    body,
+  });
+  if (!res.ok) throw new Error(`Token exchange failed (${res.status})`);
+  return (await res.json()) as XTokenResponse;
+}
+
+export async function createTweet(accessToken: string, text: string, replyToId?: string) {
+  const payload = replyToId ? { text, reply: { in_reply_to_tweet_id: replyToId } } : { text };
+  const res = await fetch("https://api.x.com/2/tweets", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const resetAt = res.headers.get("x-rate-limit-reset");
+  if (res.status === 429) {
+    const when = resetAt ? Number(resetAt) * 1000 : Date.now() + 15 * 60 * 1000;
+    return { rateLimitedUntil: new Date(when), ok: false as const, data: null };
+  }
+  const json = await res.json();
+  if (!res.ok) throw new Error(`Tweet create failed (${res.status}): ${JSON.stringify(json)}`);
+  return { ok: true as const, data: json, rateLimitedUntil: null };
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,5 @@
+import type { NextConfig } from "next";
+
+const nextConfig: NextConfig = {};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "x-auto-poster",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "db:push": "prisma db push",
+    "db:seed": "tsx prisma/seed.ts"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.20.0",
+    "clsx": "^2.1.1",
+    "date-fns": "^3.6.0",
+    "next": "14.2.10",
+    "react": "18.3.1",
+    "react-dom": "18.3.1",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^20.16.5",
+    "@types/react": "^18.3.5",
+    "@types/react-dom": "^18.3.0",
+    "autoprefixer": "^10.4.20",
+    "eslint": "^8.57.0",
+    "eslint-config-next": "14.2.10",
+    "postcss": "^8.4.47",
+    "prisma": "^5.20.0",
+    "tailwindcss": "^3.4.13",
+    "tsx": "^4.19.1",
+    "typescript": "^5.6.2"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,60 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = env("DATABASE_URL")
+}
+
+enum PostStatus {
+  DRAFT
+  SCHEDULED
+  PUBLISHED
+  FAILED
+}
+
+model User {
+  id                 String    @id @default(cuid())
+  xUserId            String?   @unique
+  handle             String?
+  accessToken        String?
+  refreshToken       String?
+  rateLimitedUntil   DateTime?
+  dailyPostLimit     Int       @default(20)
+  requireApproval    Boolean   @default(true)
+  createdAt          DateTime  @default(now())
+  updatedAt          DateTime  @updatedAt
+  posts              Post[]
+}
+
+model Post {
+  id                 String      @id @default(cuid())
+  userId             String
+  user               User        @relation(fields: [userId], references: [id], onDelete: Cascade)
+  content            String
+  threadIndex        Int         @default(0)
+  groupId            String?
+  scheduledFor       DateTime?
+  lastAttemptAt      DateTime?
+  publishedAt        DateTime?
+  status             PostStatus  @default(DRAFT)
+  retryCount         Int         @default(0)
+  approved           Boolean     @default(false)
+  createdAt          DateTime    @default(now())
+  updatedAt          DateTime    @updatedAt
+  logs               PublishLog[]
+
+  @@index([status, scheduledFor])
+  @@index([groupId, threadIndex])
+}
+
+model PublishLog {
+  id           String    @id @default(cuid())
+  postId        String
+  post          Post      @relation(fields: [postId], references: [id], onDelete: Cascade)
+  attemptedAt   DateTime  @default(now())
+  success       Boolean
+  statusCode    Int?
+  message       String
+}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,11 @@
+import { prisma } from "../lib/prisma";
+
+async function main() {
+  await prisma.user.upsert({
+    where: { id: "default-user" },
+    update: {},
+    create: { id: "default-user", requireApproval: true, dailyPostLimit: 10 },
+  });
+}
+
+main().finally(async () => prisma.$disconnect());

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx,mdx}",
+    "./components/**/*.{js,ts,jsx,tsx,mdx}",
+  ],
+  theme: { extend: {} },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {"@/*": ["./*"]}
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation
- Provide a minimal, safe-by-default web app to draft, queue, schedule, and publish posts to X using the official X API v2 and OAuth 2.0 PKCE. 
- Enforce compliance and safety controls such as approval gates, daily posting limits, safety delay between posts, duplicate prevention, retry/backoff, and rate-limit handling.
- Offer a simple dashboard and a cron-friendly endpoint so scheduled posts can be published automatically on a minute cadence.

### Description
- Bootstrapped a Next.js + TypeScript + Tailwind project and added environment validation in `lib/env.ts` and an `.env.example` with the required variables (`X_CLIENT_ID`, `X_CLIENT_SECRET`, `X_REDIRECT_URI`, `DATABASE_URL`, `CRON_SECRET`).
- Added Prisma SQLite schema (`prisma/schema.prisma`) for `User`, `Post`, and `PublishLog` with enums and fields to support scheduling, retries, approval, daily limits, and rate-limit cooldowns, plus a seed script (`prisma/seed.ts`).
- Implemented X OAuth PKCE helpers (`lib/x-auth.ts`), X client functions to exchange tokens and create tweets (`lib/x-client.ts`), and auth endpoints `GET /api/auth/x/login` and `GET /api/auth/x/callback` to perform login and token storage.
- Implemented post management and publishing flow: `GET/POST /api/posts` with duplicate draft/scheduled blocking, `POST /api/posts/:id/publish` for manual posting, `POST /api/cron/publish` protected by `x-cron-secret` for scheduler invocation, and the publish engine (`lib/publisher.ts`) which applies approval checks, daily limit, safety delay, retry/backoff, rate-limit handling, and creates `PublishLog` entries.
- Added a simple client-side Dashboard component (`components/dashboard.tsx`) and `app/page.tsx` to compose, schedule, approve, list posts and logs, and trigger manual `Post Now` actions, and updated `README.md` with setup and deployment instructions.

### Testing
- Attempted dependency installation with `npm install`, but it failed in this environment due to an npm registry `403 Forbidden`, so dependencies could not be installed and no runtime/build tests were executed. 
- No further automated tests (build, start, or integration) were run because the environment prevented installing dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69f30017a0d48327874cd3f132c55159)