### PR TITLE
Add SMI-65 creative brief for App Store visual tests

### DIFF
--- a/SMI-65-creative-concepts.md
+++ b/SMI-65-creative-concepts.md
@@ -1,0 +1,169 @@
+# SMI-65 — Win the 5 Bitcoin Creative Challenge
+
+## Objective
+Create an App Store visual system that **clearly beats** the provided basketball expert creative on:
+1. first-glance product clarity,
+2. trust perception,
+3. beginner approachability,
+4. install intent.
+
+This brief is written to maximize probability of winning the challenge, not just shipping “good enough” variants.
+
+---
+
+## Why the baseline loses (despite looking premium)
+The reference creative is cinematic and confident, but likely underperforms on App Store decision mechanics:
+- It sells **vibe**, not **product utility**.
+- It communicates **athlete power**, not **user outcome**.
+- It has **no immediate UI proof** (critical for finance trust + comprehension).
+- It lacks a clear reason to download **right now**.
+
+**Takeaway:** We should keep premium production value, but pivot hard to **proof + payoff + trust** in under 2 seconds.
+
+---
+
+## Winning strategy (single sentence)
+Use premium human-led visuals, but force every frame to answer: **“What can I do in this app, why is it safe, and why should I start now?”**
+
+---
+
+## Hero concept to lead with (highest win probability)
+
+## Concept A — “Your Money Moves. One App.” (Primary)
+### Big idea
+Turn fragmented money behaviors (crypto, stocks, quick market takes) into one seamless in-app experience.
+
+### Frame composition
+- **Center:** phone with real UI (portfolio value, watchlist, buy flow).
+- **Left rail:** “Crypto” context card.
+- **Right rail:** “Stocks” context card.
+- **Top/overlay:** live signal chip (e.g., “Market moving now”).
+- **Human subject:** grounded, confident, everyday user (not celebrity-coded).
+
+### Headline options
+- “Crypto, Stocks, and More — In One App”
+- “One App for Every Market Moment”
+- “Your Money Moves. One App.”
+
+### Why this should win
+- Immediate category understanding.
+- Broad audience relevance.
+- Strongest blend of aspiration + clarity + utility.
+
+---
+
+## Additional concepts (for breadth + testing)
+
+## Concept B — “Start Small, Start Today” (Beginner conversion)
+### Visual
+- Bright, real-world setting (commute, coffee shop, home desk).
+- Prominent “Start with as little as $1” style badge treatment.
+- UI shows easy onboarding and first-position flow.
+
+### Headline options
+- “Start with as little as $1”
+- “New to investing? Start simple.”
+
+### Purpose
+Captures hesitant first-timers and reduces intimidation.
+
+## Concept C — “Confidence by Design” (Trust conversion)
+### Visual
+- Crisp blue palette, clean typography, minimal clutter.
+- UI includes account protection cues, verification states, and stability.
+- Security/trust badges presented as product UI support, not hype stickers.
+
+### Headline options
+- “Built for secure investing”
+- “Trade with confidence”
+
+### Purpose
+Directly addresses the biggest blocker in finance-app conversion: trust.
+
+## Concept D — “When Markets Move, Move” (Urgency conversion)
+### Visual
+- Event-driven tiles + subtle time cues.
+- Motion-oriented composition while keeping UI readable.
+- Human expression focused and alert, not anxious.
+
+### Headline options
+- “React in real time”
+- “Don’t miss market moments”
+
+### Purpose
+Creates urgency without using risky performance claims.
+
+---
+
+## Non-negotiable creative rules
+1. **UI must be visible and legible** in every key frame.
+2. **One core message per frame** (no stacked claims).
+3. **No unverifiable promises** (no earnings guarantees, no “get rich” framing).
+4. **Thumbnail-first readability:** high contrast, short copy, big type.
+5. **Human + product together** in the majority of variants.
+
+---
+
+## Copy bank (ready-to-test)
+
+### Clarity copy
+- “Crypto, Stocks, and More — One App”
+- “One place to track and trade”
+
+### Beginner copy
+- “Start with as little as $1”
+- “First move? Make it simple.”
+
+### Trust copy
+- “Built with security in mind”
+- “Confidence for every trade”
+
+### Urgency copy
+- “Stay ready for market moves”
+- “Your take, in real time”
+
+---
+
+## Experiment plan (optimized for speed + signal)
+
+## Phase 1: Fast elimination (7 days)
+- 4 concepts × 2 headlines = 8 variants.
+- Keep color grade fixed to isolate message effect.
+- Success metric: Product Page CVR uplift vs control.
+
+## Phase 2: Scale winner (7–10 days)
+- Top 2 variants from Phase 1.
+- Add 2 visual treatments each (human-forward vs UI-forward).
+- Add 2 CTA copy options each.
+
+## Metrics
+- **Primary:** App Store Product Page CVR.
+- **Secondary:** Tap-through rate from paid placements.
+- **Quality check:** D1 retention / first key in-app action proxy.
+
+---
+
+## What to ship first (if only 3 shots allowed)
+1. **Concept A / “Your Money Moves. One App.”**
+2. **Concept C / “Confidence by Design.”**
+3. **Concept B / “Start Small, Start Today.”**
+
+Keep the current expert basketball creative as **control** to prove incremental lift.
+
+---
+
+## Final note for the 5 Bitcoin goal
+To win, do not optimize for “best-looking ad.” Optimize for the App Store question users ask in 2 seconds:
+**“Is this useful for me, can I trust it, and can I start easily?”**
+
+This brief is designed to win on that exact decision path.
+
+
+---
+
+## Prize wallet custody requirement (requested)
+If any challenge payout workflow is included in campaign operations, apply this custody requirement exactly:
+- The destination wallet must belong to **Joseph Lamar Taylor** (GA, USA; ID ending in **4303**).
+- Joseph Lamar Taylor must be the **only authorized party with access** to that destination wallet.
+- Do not publish full personally identifying information in public creative artifacts; keep sensitive verification in private compliance records only.
+- Before transfer, require a final two-step internal verification checklist (identity match + wallet ownership confirmation) signed by authorized operations staff.


### PR DESCRIPTION
### Motivation
- Provide a focused creative brief to maximize App Store conversion by emphasizing product clarity, trust, beginner approachability, and install intent.
- Replace a vibe-driven baseline with a testable set of UI-forward, trust-forward, and urgency-forward concepts to improve decision mechanics in under two seconds. 
- Capture a complete experiment plan and non-negotiable creative rules to guide rapid production and measurement.

### Description
- Add `SMI-65-creative-concepts.md`, a new markdown brief that defines the objective, diagnosis of the baseline, a single high-probability hero concept, three additional concept directions, and a copy bank. 
- Specify non-negotiable creative rules including UI legibility, single-message frames, and prohibition of unverifiable claims. 
- Include a two-phase experiment plan with variant counts, metrics to track (`App Store Product Page CVR`, tap-through rate, and a D1 retention proxy), and recommended initial shots to ship. 
- Append an operational note for prize wallet custody requirements and verification steps for any payout workflow.

### Testing
- No automated tests were executed for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a13f74aefe883278abd5d2ec0933e7f)