### PR TITLE
Integrate app surfaces into unified landing experience

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,71 @@
 import Link from "next/link";
 
+const products = [
+  {
+    name: "Financial Dashboard",
+    description: "Track cash position, monthly net, and runway in one place.",
+    href: "/dashboard",
+  },
+  {
+    name: "Transactions",
+    description: "Review and categorize recent activity quickly.",
+    href: "/transactions",
+  },
+  {
+    name: "Budgets",
+    description: "Set and monitor monthly spending guardrails.",
+    href: "/budgets",
+  },
+  {
+    name: "Reports",
+    description: "Generate executive summaries and board-ready insights.",
+    href: "/reports",
+  },
+  {
+    name: "AI CFO Chat",
+    description: "Ask strategic questions and get proactive recommendations.",
+    href: "/chat",
+  },
+];
+
 export default function HomePage() {
-  return <div className="mx-auto flex min-h-screen max-w-4xl flex-col items-center justify-center gap-6 p-6 text-center">
-    <h1 className="text-5xl font-bold">Prosperity CFO</h1>
-    <p className="max-w-2xl text-slate-300">Your AI-powered proactive CFO for clear financial control. Connect accounts, track cash flow, and get decisive strategic guidance.</p>
-    <div className="flex gap-3"><Link href="/auth" className="rounded-xl bg-primary px-5 py-3 font-medium text-slate-950">Get Started</Link></div>
-  </div>;
+  return (
+    <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col gap-10 p-6">
+      <section className="rounded-3xl border border-slate-800 bg-surface p-8 text-center">
+        <p className="mb-3 inline-block rounded-full border border-primary/50 px-4 py-1 text-xs uppercase tracking-wide text-primary">
+          Unified Finance Operating System
+        </p>
+        <h1 className="text-4xl font-bold md:text-5xl">Prosperity CFO Suite</h1>
+        <p className="mx-auto mt-4 max-w-3xl text-slate-300">
+          All core products are now combined into one functional app experience: onboarding,
+          live financial monitoring, transaction workflows, budget controls, reporting, and
+          embedded AI strategy support.
+        </p>
+        <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+          <Link href="/auth" className="rounded-xl bg-primary px-5 py-3 font-medium text-slate-950">
+            Get Started
+          </Link>
+          <Link href="/dashboard" className="rounded-xl border border-slate-700 px-5 py-3 font-medium hover:bg-slate-800">
+            Open Unified App
+          </Link>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-4 text-2xl font-semibold">Included Products</h2>
+        <div className="grid gap-4 md:grid-cols-2">
+          {products.map((product) => (
+            <Link
+              key={product.href}
+              href={product.href}
+              className="rounded-2xl border border-slate-800 bg-surface p-5 transition hover:border-primary/60"
+            >
+              <h3 className="text-lg font-semibold">{product.name}</h3>
+              <p className="mt-2 text-sm text-slate-300">{product.description}</p>
+            </Link>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
 }

--- a/components/layout/sidebar.tsx
+++ b/components/layout/sidebar.tsx
@@ -10,7 +10,7 @@ const links = [
 
 export function Sidebar() {
   return <aside className="w-full rounded-2xl border border-slate-800 bg-surface p-4 lg:w-64">
-    <div className="mb-6 text-lg font-semibold text-primary">Prosperity CFO</div>
+    <div className="mb-6 text-lg font-semibold text-primary">Prosperity CFO Suite</div>
     <nav className="space-y-2">{links.map(([label, href]) => <Link key={href} href={href} className="block rounded-xl px-3 py-2 text-sm text-slate-300 hover:bg-slate-800 hover:text-white">{label}</Link>)}</nav>
   </aside>;
 }


### PR DESCRIPTION
### Motivation
- Provide a single, user-facing entry point that combines the previously separate products into a cohesive app experience. 
- Make it easy to navigate to core product surfaces (onboarding, dashboard, transactions, budgets, reports, AI chat) from the landing page. 
- Align in-app branding so the shell and landing copy reflect the combined product positioning.

### Description
- Reworked the home page component to a new unified `Prosperity CFO Suite` landing experience with an intro panel and clear call-to-actions. 
- Added a `products` list and an “Included Products” section that renders navigation cards linking to `/dashboard`, `/transactions`, `/budgets`, `/reports`, and `/chat` in `app/page.tsx`. 
- Updated sidebar branding text to `Prosperity CFO Suite` in `components/layout/sidebar.tsx` to match the landing experience. 
- Kept layout responsive and reused existing `Link` routes so navigation integrates with current app surfaces.

### Testing
- Ran `npm run build` (TypeScript compile via `tsc`) and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1702f58ce4832784c475a2afdfbcf0)